### PR TITLE
Explicit HREF Check for URL Paramter

### DIFF
--- a/Widgets/ExperienceBuilder/oriented-imagery/src/runtime/widget.tsx
+++ b/Widgets/ExperienceBuilder/oriented-imagery/src/runtime/widget.tsx
@@ -385,7 +385,7 @@ export default class Widget extends BaseWidget<AllWidgetProps<IMConfig>, State>{
       
 
     }
-    if (window.location.href.indexOf('oic') !== -1) {
+    if (window.location.href.indexOf('oic=') !== -1) {
         let v = window.location.href.split('oic=')[1];
         if (v) {
           this.oicList[0] = ("https://www.arcgis.com/sharing/rest/content/items/" + v.split("&")[0]);


### PR DESCRIPTION
If a user deploys the Experience Builder OIC Widget where the application has "oic" in the path (e.g. https://a.b.c/oic-viewer), but does not have a URL parameter named "oic", the Widget will fail to load due to the split function in the loadOIC function. This addition assumes a more explicit check for "oic=" will reduce headaches. It is also possible there is documentation that covers this issue and the user who raised this problem just needed a better way to prevent the error from happening.

